### PR TITLE
chore: bump step-security/harden-runner to v2.19.0

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -24,7 +24,7 @@ jobs:
     name: Action lint
     runs-on: ubuntu-latest
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/use-action.yaml
+++ b/.github/workflows/use-action.yaml
@@ -16,7 +16,7 @@ jobs:
       id-token: write # Needed to federate with octo-sts
 
     steps:
-      - uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: block
           allowed-endpoints: >

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: read # Clone the repository
       security-events: write # Upload SARIF results to Code Scanning
     steps:
-      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: block
           allowed-endpoints: >


### PR DESCRIPTION
## Summary
- Bump `step-security/harden-runner` to `v2.19.0` (SHA `8d3c67de8e2fe68ef647c8db1e6a09f647780f40`), the latest release (2026-04-20).
- Replaces older pins so all workflows in this repo meet the ≥v2.17.0 org hardening bar.

Automated bump as part of an org-wide audit; no config flags changed.

## Test plan
- [ ] CI passes on this PR
- [ ] harden-runner initializes with the existing `egress-policy` in each workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)