### PR TITLE
fix(ci): add zizmor pedantic persona and suppress noisy findings

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -36,3 +36,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -7,3 +7,9 @@ rules:
   dependabot-cooldown:
     config:
       days: 3
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
# fix(ci): add zizmor pedantic persona and suppress noisy findings

## Summary

This repo was largely clean: all action refs were already SHA-pinned and harden-runner
was already present in all jobs. The only automated fix is updating `.github/zizmor.yml`
to suppress low-value noisy rules and enable the pedantic persona in CI.

## Changes

- **Patch 1**: Update `.github/zizmor.yml` to suppress `concurrency-limits`,
  `anonymous-definition`, and `undocumented-permissions`; switch CI zizmor to
  `--pedantic` persona

## Manual review items

- **CRITICAL**: `dangerous-triggers` — `pull_request_target` trigger in
  `use-action.yaml` runs the action from the PR fork with `id-token: write`. See
  `manual-review.md` for full analysis and remediation options.

## Testing

- zizmor finding count before: 4 (3x concurrency-limits, 1x dangerous-triggers)
- After applying patch: 1 remaining (dangerous-triggers — intentional, requires
  architectural fix documented in manual-review.md)
- actionlint: 0 findings
- All action refs already SHA-pinned

## References

- Linear: PSEC-923
- Branch: security/psec-923-action